### PR TITLE
Also prevent "Enter" on "Messages" page

### DIFF
--- a/content.js
+++ b/content.js
@@ -14,10 +14,7 @@ function check() {
 
     // if it is "Messages" page, get different DOM
     if (isMessagePage()) {
-        elem_array = document.xpath('//*[@id="react-root"]/div/div/div[2]/main');
-        if (elem_array.length > 0) {
-            elem = elem_array[0];
-        }
+        elem = document.querySelector('main');
     }
     else {
         elem = document.querySelector('[data-testid~="DMDrawer"]');
@@ -47,21 +44,5 @@ function isMessagePage() {
     }
     else {
         return false;
-    }
-}
-
-// to get element by xpath
-document.xpath = function (expression) {
-    ret = document.evaluate(expression, document, null, XPathResult.ANY_TYPE, null);
-    switch (ret.resultType) {
-        case 1: return ret.numberValue;
-        case 2: return ret.stringValue;
-        case 3: return ret.booleanValue;
-        case 4:
-        case 5:
-            var a = [];
-            while (e = ret.iterateNext()) { a.push(e); };
-            return a;
-        default: return ret;
     }
 }

--- a/content.js
+++ b/content.js
@@ -1,7 +1,29 @@
+// 1. If "Messages" page: get DOM
+// 2. Other page: get just "DM window" DOM
+// 3. Prevent Enter keydown within the DOM
+
 const checkIntervalID = setInterval(check, 1000);
+
+// when clicked, check URL. If URL changed, re-define the DOM
+window.addEventListener('click', function () {
+    check();
+})
+
 function check() {
-    const elem = document.querySelector('[data-testid~="DMDrawer"]');
-    if(elem != null) {
+    var elem;
+
+    // if it is "Messages" page, get different DOM
+    if (isMessagePage()) {
+        elem_array = document.xpath('//*[@id="react-root"]/div/div/div[2]/main');
+        if (elem_array.length > 0) {
+            elem = elem_array[0];
+        }
+    }
+    else {
+        elem = document.querySelector('[data-testid~="DMDrawer"]');
+    }
+
+    if (elem != null) {
         elem.onkeydown = onkeydown;
         clearInterval(checkIntervalID);
     }
@@ -13,5 +35,33 @@ function onkeydown(e) {
         e.preventDefault();
         e.stopPropagation();
         e.stopImmediatePropagation();
+    }
+}
+
+// check URL to know if it is "Messages" page or not
+function isMessagePage() {
+    var page_url = location.href;
+    const message_url_pattern = /https:\/\/twitter.com\/messages/;
+    if (message_url_pattern.test(page_url)) {
+        return true;
+    }
+    else {
+        return false;
+    }
+}
+
+// to get element by xpath
+document.xpath = function (expression) {
+    ret = document.evaluate(expression, document, null, XPathResult.ANY_TYPE, null);
+    switch (ret.resultType) {
+        case 1: return ret.numberValue;
+        case 2: return ret.stringValue;
+        case 3: return ret.booleanValue;
+        case 4:
+        case 5:
+            var a = [];
+            while (e = ret.iterateNext()) { a.push(e); };
+            return a;
+        default: return ret;
     }
 }


### PR DESCRIPTION
1. Twitter.com の Messages ページでも、同様に「Enter」が制限されるようにした

2. 以下の説明を追記
// 1. If "Message" page: get DOM
// 2. Other page: get just "DM window" DOM
// 3. Prevent Enter keydown within the DOM

# イシュー
既存の機能では、以下の「Messages」ページで、まだ「Enter」が制限されておらず送信コマンドになっていた。
![image](https://user-images.githubusercontent.com/46485088/164891153-b5009137-3471-422e-9def-30f1d08d5c9a.png)

# 対応
以下の様に、「Messages」ページにおいても「Enter」が制限されるように機能追加
![スクリーンショット 2022-04-23 184620](https://user-images.githubusercontent.com/46485088/164891213-353f0dad-9aef-47e9-bca0-35ed75173f7f.png)



close: https://github.com/gyojir/twitter-dm-no-submit-on-enter/issues/1